### PR TITLE
Move the `DebugInterface` class inside the Go client

### DIFF
--- a/clients/go/debugging_interface/debug_interface.go
+++ b/clients/go/debugging_interface/debug_interface.go
@@ -1,4 +1,4 @@
-package debugginginterface
+package debugging_interface
 
 import (
     "bufio"

--- a/clients/go/debugginginterface/debug_interface.go
+++ b/clients/go/debugginginterface/debug_interface.go
@@ -1,4 +1,4 @@
-package main
+package debugginginterface
 
 import (
     "bufio"

--- a/clients/go/main.go
+++ b/clients/go/main.go
@@ -7,7 +7,7 @@ import (
     . "ai_cup_22/codegame"
     . "ai_cup_22/model"
     . "ai_cup_22/stream"
-    . "ai_cup_22/debugginginterface"
+    . "ai_cup_22/debugging_interface"
     "strconv"
 )
 

--- a/clients/go/main.go
+++ b/clients/go/main.go
@@ -7,6 +7,7 @@ import (
     . "ai_cup_22/codegame"
     . "ai_cup_22/model"
     . "ai_cup_22/stream"
+    . "ai_cup_22/debugginginterface"
     "strconv"
 )
 

--- a/clients/go/my_strategy.go
+++ b/clients/go/my_strategy.go
@@ -2,7 +2,7 @@ package main
 
 import (
     . "ai_cup_22/model"
-    . "ai_cup_22/debugginginterface"
+    . "ai_cup_22/debugging_interface"
 )
 
 type MyStrategy struct{}

--- a/clients/go/my_strategy.go
+++ b/clients/go/my_strategy.go
@@ -2,6 +2,7 @@ package main
 
 import (
     . "ai_cup_22/model"
+    . "ai_cup_22/debugginginterface"
 )
 
 type MyStrategy struct{}


### PR DESCRIPTION
I moved the `DebugInterface` class into a separate package so that it could be imported from the outside.