### PR TITLE
If `setup.py` is present, then build extension modules using it.

### DIFF
--- a/clients/python/entrypoint.sh
+++ b/clients/python/entrypoint.sh
@@ -4,7 +4,11 @@ PROJECT_NAME="ai_cup_22"
 SOLUTION_CODE_ENTRYPOINT="my_strategy.py"
 function compile() (
     set -e
-    find . -name '*.pyx' -exec cythonize -i {} \;
+    if [ -f "setup.py" ]; then
+      python setup.py build_ext --inplace
+    else
+      find . -name '*.pyx' -exec cythonize -i {} \;
+    fi
     python -m py_compile main.py
     zip -r - . > /tmp/$PROJECT_NAME.zip
 )


### PR DESCRIPTION
`setup.py` provides much more ways to tweak the build of extension modules. So if it's present then it's better to build using it.