### PR TITLE
Add includes for not WIN32 system

### DIFF
--- a/clients/cpp/TcpStream.cpp
+++ b/clients/cpp/TcpStream.cpp
@@ -1,3 +1,7 @@
+#ifndef _WIN32
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+#endif
 #include "TcpStream.hpp"
 #include <cstring>
 #include <stdexcept>

--- a/clients/cpp_variant/TcpStream.cpp
+++ b/clients/cpp_variant/TcpStream.cpp
@@ -1,3 +1,7 @@
+#ifndef _WIN32
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+#endif
 #include "TcpStream.hpp"
 #include <cstring>
 #include <stdexcept>


### PR DESCRIPTION
IPPROTO_TCP was used but not declared. The reason is lack of includes. On Linux they are making no sense, but on FreeBSD these includes must be in program before using IPPROTO_TCP.